### PR TITLE
Refactoring initialisation templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules
 .prettierrc
 .DS_Store
 .env
+scratch1.ts
+

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@elemaudio/core": "^1.0.8",
-		"@elemaudio/web-renderer": "^1.0.16",
+		"@elemaudio/core": "^2.0.0",
+		"@elemaudio/web-renderer": "^2.0.0",
 		"@steeze-ui/carbon-icons": "^1.1.2",
 		"@steeze-ui/heroicons": "^2.2.2",
 		"@steeze-ui/svelte-icon": "^1.3.2",

--- a/src/lib/audio/AudioFunctions.ts
+++ b/src/lib/audio/AudioFunctions.ts
@@ -13,7 +13,7 @@
 import { AudioMain, MainAudioClass } from '$lib/classes/Audio';
 import { el } from '@elemaudio/core';
 import { channelExtensionFor, clipTo0 } from '$lib/classes/Utils';
-import { attenuate, clippedHann, progress } from '$lib/audio/El Funktions';
+import { attenuate, clippedHann, progress } from '$lib/audio/Funktions';
 import type { StereoSignal, SamplerOptions, ProgressOptions, Signal } from '../../typeDeclarations';
 import { ContextSampleRate, Scrubbing } from '$lib/stores/stores';
 import { get } from 'svelte/store';

--- a/src/lib/audio/AudioFunctions.ts
+++ b/src/lib/audio/AudioFunctions.ts
@@ -6,11 +6,11 @@
  * memoized composite function, defined in the composites.ts file.
  * 
  * From here, we pass back a StereoSignal object, 
- * which is returned to the Elementary Core renderer in Audio.ts
+ * which is returned to the Elementary Core renderer in Music.ts
  * 
  */
 
-import { Audio, AudioCore } from '$lib/classes/Audio';
+import { Audio, MainAudio } from '$lib/classes/Audio';
 import { el } from '@elemaudio/core';
 import { channelExtensionFor, clipTo0 } from '$lib/classes/Utils';
 import { attenuate, clippedHann, progress } from '$lib/audio/El Funktions';
@@ -84,7 +84,7 @@ export function scrubbingSamplesPlayer(props: SamplerOptions): StereoSignal {
 	const scrubRate = el.sm(el.latch(el.train(50), el.rand()));
 	const scrub: Signal = el.train(el.mul(50, scrubRate)) as Signal;
 
-	const currentVFSPath = Audio.currentVFSPath;
+	const currentVFSPath = AudioMain.currentVFSPath;
 	let path = currentVFSPath + channelExtensionFor(1);
 	let kl = currentVFSPath + '_left';
 	let kr = currentVFSPath + '_right';
@@ -120,7 +120,7 @@ export function scrubbingSamplesPlayer(props: SamplerOptions): StereoSignal {
  * ════════════════════════════════════════════════
  */
 
-export function driftingSamplesPlayer(coreClass: AudioCore, props: SamplerOptions): StereoSignal {
+export function driftingSamplesPlayer(coreClass: MainAudio, props: SamplerOptions): StereoSignal {
 	let { trigger = 1,
 		rate = 1,
 		startOffset = 0,

--- a/src/lib/audio/AudioFunctions.ts
+++ b/src/lib/audio/AudioFunctions.ts
@@ -10,7 +10,7 @@
  * 
  */
 
-import { Audio, MainAudio } from '$lib/classes/Audio';
+import { AudioMain, MainAudioClass } from '$lib/classes/Audio';
 import { el } from '@elemaudio/core';
 import { channelExtensionFor, clipTo0 } from '$lib/classes/Utils';
 import { attenuate, clippedHann, progress } from '$lib/audio/El Funktions';
@@ -120,7 +120,7 @@ export function scrubbingSamplesPlayer(props: SamplerOptions): StereoSignal {
  * ════════════════════════════════════════════════
  */
 
-export function driftingSamplesPlayer(coreClass: MainAudio, props: SamplerOptions): StereoSignal {
+export function driftingSamplesPlayer(coreClass: MainAudioClass, props: SamplerOptions): StereoSignal {
 	let { trigger = 1,
 		rate = 1,
 		startOffset = 0,

--- a/src/lib/audio/AudoEventExpressions.ts
+++ b/src/lib/audio/AudoEventExpressions.ts
@@ -1,14 +1,12 @@
 import { OutputMeters, PlaylistMusic } from "$lib/stores/stores";
-import type { CustomEventHandler, Signal } from "../../typeDeclarations";
 import { AudioMain } from "$lib/classes/Audio";
 import { hannEnvelope } from "$lib/audio/AudioFunctions";
+import type { AudioEventExpression, MessageEvent, MeterEvent } from "../../typeDeclarations";
 
-type MeterEvent = { min: number, max: number };
-type MessageEvent = { data: number | Signal };
 
-// using snapshot event to update the progress of the windowing envelope
-export const customEvents: CustomEventHandler = {
-    ['progressSignal']: function (e: MessageEvent) {
+export const eventExpressions: AudioEventExpression<any> =
+{
+    progress: (e: MessageEvent) => {
         AudioMain.updateOutputLevelWith(hannEnvelope(AudioMain.progress));
         PlaylistMusic.update(($pl) => {
             if (!$pl.currentTrack || !e.data) return $pl;
@@ -16,7 +14,7 @@ export const customEvents: CustomEventHandler = {
             return $pl;
         })
     },
-    ['meter']: function (e: MeterEvent) {
+    meter: (e: MeterEvent) => {
         OutputMeters.update(($o) => {
             const absMax = Math.max(e.max, Math.abs(e.min));
             $o = { ...$o, SpeechAudible: absMax };
@@ -24,3 +22,5 @@ export const customEvents: CustomEventHandler = {
         })
     }
 }
+
+

--- a/src/lib/audio/EventHandlers.ts
+++ b/src/lib/audio/EventHandlers.ts
@@ -9,7 +9,7 @@ type MessageEvent = { data: number | Signal };
 // using snapshot event to update the progress of the windowing envelope
 export const customEvents: CustomEventHandler = {
     ['progressSignal']: function (e: MessageEvent) {
-        Audio.updateOutputLevelWith(hannEnvelope(Audio.progress));
+        AudioMain.updateOutputLevelWith(hannEnvelope(AudioMain.progress));
         PlaylistMusic.update(($pl) => {
             if (!$pl.currentTrack || !e.data) return $pl;
             $pl.currentTrack.progress = e.data as number;

--- a/src/lib/audio/EventHandlers.ts
+++ b/src/lib/audio/EventHandlers.ts
@@ -1,6 +1,6 @@
 import { OutputMeters, PlaylistMusic } from "$lib/stores/stores";
 import type { CustomEventHandler, Signal } from "../../typeDeclarations";
-import { Audio } from "$lib/classes/Audio";
+import { AudioMain } from "$lib/classes/Audio";
 import { hannEnvelope } from "$lib/audio/AudioFunctions";
 
 type MeterEvent = { min: number, max: number };

--- a/src/lib/audio/EventHandlers.ts
+++ b/src/lib/audio/EventHandlers.ts
@@ -1,0 +1,26 @@
+import { OutputMeters, PlaylistMusic } from "$lib/stores/stores";
+import type { CustomEventHandler, Signal } from "../../typeDeclarations";
+import { Audio } from "$lib/classes/Audio";
+import { hannEnvelope } from "$lib/audio/AudioFunctions";
+
+type MeterEvent = { min: number, max: number };
+type MessageEvent = { data: number | Signal };
+
+// using snapshot event to update the progress of the windowing envelope
+export const customEvents: CustomEventHandler = {
+    ['progressSignal']: function (e: MessageEvent) {
+        Audio.updateOutputLevelWith(hannEnvelope(Audio.progress));
+        PlaylistMusic.update(($pl) => {
+            if (!$pl.currentTrack || !e.data) return $pl;
+            $pl.currentTrack.progress = e.data as number;
+            return $pl;
+        })
+    },
+    ['meter']: function (e: MeterEvent) {
+        OutputMeters.update(($o) => {
+            const absMax = Math.max(e.max, Math.abs(e.min));
+            $o = { ...$o, SpeechAudible: absMax };
+            return $o;
+        })
+    }
+}

--- a/src/lib/audio/Funktions.ts
+++ b/src/lib/audio/Funktions.ts
@@ -123,7 +123,6 @@ export function progress(props: {
 	rate?: number;
 	startOffset?: number;
 }): Signal {
-
 	let { run,
 		totalDurMs = 0,
 		rate = 1000,
@@ -138,7 +137,6 @@ export function progress(props: {
 
 	let progress = el.add(el.phasor(pausingRateSignal, reset), el.sm(numberToConstant('startOffset', startOffset as number)));
 	let trig = el.train(el.mul(rate, run))
-
 	return (
 		el.snapshot({ key, name: 'progress' }, trig, progress)
 	);

--- a/src/lib/classes/Assets.ts
+++ b/src/lib/classes/Assets.ts
@@ -6,7 +6,7 @@ import {
 import { get } from "svelte/store";
 import type { AssetCategories, AudioAssetMetadata, StructuredAssetContainer } from "../../typeDeclarations";
 import type WebAudioRenderer from "@elemaudio/web-renderer";
-import { Audio as Music } from "./Audio";
+import { AudioMain as Music } from "./Audio";
 import { VoiceOver as Speech } from "./Speech";
 
 export function assign(

--- a/src/lib/classes/Assets.ts
+++ b/src/lib/classes/Assets.ts
@@ -65,9 +65,6 @@ export function sumLengthsOfAllArraysInVFSStore() {
 }
 
 export function coreForCategory(category: AssetCategories): WebAudioRenderer {
-
-    console.log('coreForCategory ', category)
-
     switch (category) {
         case 'music':
             return Music._core;

--- a/src/lib/classes/Speech.ts
+++ b/src/lib/classes/Speech.ts
@@ -22,12 +22,13 @@ export class VoiceCore extends MainAudioClass {
 
 	constructor() {
 		super();
-		this._core = null as unknown as WebAudioRenderer;
+		this._core = new WebAudioRenderer();
 		this._voiceCoreStatus = writable('loading');
 		this._voiceVolume = 0.727;
 
 		// below gets updated from store subscription
 		this._currentMetadata = { title: '', vfsPath: '', duration: 0 };
+		this.subscribeToStores();
 	}
 
 	override subscribeToStores(): void {
@@ -42,30 +43,17 @@ export class VoiceCore extends MainAudioClass {
 	 * asynchronously and store in VoiceCore class as this._endNodes
 	 */
 	override async init(): Promise<void> {
-		this._core = new WebAudioRenderer();
-		while (!super.actx) {
-			console.log('Waiting for first WebAudioRenderer instance to load...');
-			await new Promise((resolve) => setTimeout(resolve, 50));
-		}
 		const metering: Functionality = customEvents.meter
-		VoiceOver.subscribeToStores()
-		super.init(
-			{ id: 'speech', renderer: VoiceOver._core },
-			super.actx,
-			{
-				connectTo: { sidechain: true },
+		super.init({
+			namedRenderer: {
+				id: 'speech',
+				renderer: VoiceOver._core
+			},
+			options: {
+				connectTo: { sidechain: true, destination: true },
 				extraFunctionality: [metering]
 			}
-		);
-
-
-		// VoiceOver._core.on('load', () => {
-		// 	VoiceOver.subscribeToStores()
-		// 	SpeechCoreLoaded.set(true);
-		// 	VoiceOver.status = 'ready';
-		// 	console.log('Speech core loaded  🎤');
-		// 	VoiceOver.patch();
-		// });	
+		})
 	}
 
 	// /**

--- a/src/lib/classes/Speech.ts
+++ b/src/lib/classes/Speech.ts
@@ -2,7 +2,7 @@ import type { AssetMetadata, MainAudioStatus, Functionality, Signal, StereoSigna
 import { get } from 'svelte/store';
 import WebAudioRenderer from '@elemaudio/web-renderer';
 import { writable, type Writable } from 'svelte/store';
-import { MainAudio } from '$lib/classes/Audio';
+import { MainAudioClass } from '$lib/classes/Audio';
 import { el } from '@elemaudio/core';
 import { OutputMeters, PlaylistMusic, SpeechCoreLoaded } from '$lib/stores/stores';
 import { attenuateStereo, driftingSamplesPlayer } from '$lib/audio/AudioFunctions';
@@ -14,7 +14,7 @@ import { customEvents } from '$lib/audio/EventHandlers';
 * @todo swap into different chapters / tracks on the fly
 */
 
-export class VoiceCore extends MainAudio {
+export class VoiceCore extends MainAudioClass {
 	_core: WebAudioRenderer;
 	_voiceCoreStatus: Writable<MainAudioStatus>;
 	_voiceVolume: number | Signal;

--- a/src/lib/classes/Speech.ts
+++ b/src/lib/classes/Speech.ts
@@ -1,8 +1,8 @@
-import type { AssetMetadata, AudioCoreStatus, Functionality, Signal, StereoSignal } from '../../typeDeclarations';
+import type { AssetMetadata, MainAudioStatus, Functionality, Signal, StereoSignal } from '../../typeDeclarations';
 import { get } from 'svelte/store';
 import WebAudioRenderer from '@elemaudio/web-renderer';
 import { writable, type Writable } from 'svelte/store';
-import { AudioCore } from '$lib/classes/Audio';
+import { MainAudio } from '$lib/classes/Audio';
 import { el } from '@elemaudio/core';
 import { OutputMeters, PlaylistMusic, SpeechCoreLoaded } from '$lib/stores/stores';
 import { attenuateStereo, driftingSamplesPlayer } from '$lib/audio/AudioFunctions';
@@ -14,9 +14,9 @@ import { customEvents } from '$lib/audio/EventHandlers';
 * @todo swap into different chapters / tracks on the fly
 */
 
-export class VoiceCore extends AudioCore {
+export class VoiceCore extends MainAudio {
 	_core: WebAudioRenderer;
-	_voiceCoreStatus: Writable<AudioCoreStatus>;
+	_voiceCoreStatus: Writable<MainAudioStatus>;
 	_voiceVolume: number | Signal;
 	_currentMetadata: AssetMetadata;
 
@@ -130,7 +130,7 @@ export class VoiceCore extends AudioCore {
 	set voiceVolume(volume: number | Signal) {
 		this._voiceVolume = volume;
 	}
-	set status(status: AudioCoreStatus) {
+	set status(status: MainAudioStatus) {
 		this._voiceCoreStatus.update((s) => {
 			return status;
 		});

--- a/src/lib/classes/Speech.ts
+++ b/src/lib/classes/Speech.ts
@@ -4,7 +4,7 @@ import WebAudioRenderer from '@elemaudio/web-renderer';
 import { writable, type Writable } from 'svelte/store';
 import { MainAudioClass } from '$lib/classes/Audio';
 import { el } from '@elemaudio/core';
-import { OutputMeters, PlaylistMusic, SpeechCoreLoaded } from '$lib/stores/stores';
+import { PlaylistMusic } from '$lib/stores/stores';
 import { attenuateStereo, driftingSamplesPlayer } from '$lib/audio/AudioFunctions';
 import { customEvents } from '$lib/audio/EventHandlers';
 

--- a/src/lib/classes/Speech.ts
+++ b/src/lib/classes/Speech.ts
@@ -1,28 +1,29 @@
-import type { AssetMetadata, AudioCoreStatus, Signal, StereoSignal } from '../../typeDeclarations';
+import type { AssetMetadata, AudioCoreStatus, Functionality, Signal, StereoSignal } from '../../typeDeclarations';
 import { get } from 'svelte/store';
-import WebRenderer from '@elemaudio/web-renderer';
+import WebAudioRenderer from '@elemaudio/web-renderer';
 import { writable, type Writable } from 'svelte/store';
 import { AudioCore } from '$lib/classes/Audio';
 import { el } from '@elemaudio/core';
 import { OutputMeters, PlaylistMusic, SpeechCoreLoaded } from '$lib/stores/stores';
 import { attenuateStereo, driftingSamplesPlayer } from '$lib/audio/AudioFunctions';
+import { customEvents } from '$lib/audio/EventHandlers';
 
-/** ════════╡ Speech WebRenderer Core ╞═══════
+
+/** ════════╡ Speech WebAudioRenderer Core ╞═══════
 * @todo set the start offset in the audio file
 * @todo swap into different chapters / tracks on the fly
 */
 
 export class VoiceCore extends AudioCore {
-	_core: WebRenderer;
+	_core: WebAudioRenderer;
 	_voiceCoreStatus: Writable<AudioCoreStatus>;
 	_voiceVolume: number | Signal;
 	_currentMetadata: AssetMetadata;
 
 	constructor() {
 		super();
-		this._core = null as unknown as WebRenderer;
+		this._core = null as unknown as WebAudioRenderer;
 		this._voiceCoreStatus = writable('loading');
-		this._endNodes = writable({ mainCore: null, silentCore: null });
 		this._voiceVolume = 0.727;
 
 		// below gets updated from store subscription
@@ -37,54 +38,47 @@ export class VoiceCore extends AudioCore {
 
 	/**
 	 * @name init
-	 * @description Initialise the main WebRenderer instances handling the Speech 
+	 * @description Initialise the main WebAudioRenderer instances handling the Speech 
 	 * asynchronously and store in VoiceCore class as this._endNodes
 	 */
 	override async init(): Promise<void> {
-		this._core = new WebRenderer();
+		this._core = new WebAudioRenderer();
 		while (!super.actx) {
-			console.log('Waiting for first WebRenderer instance to load...');
+			console.log('Waiting for first WebAudioRenderer instance to load...');
 			await new Promise((resolve) => setTimeout(resolve, 50));
 		}
-		this.voiceEndNode = await this._core
-			.initialize(super.actx, {
-				numberOfInputs: 0,
-				numberOfOutputs: 1,
-				outputChannelCount: [2]
-			})
-			.then((node) => {
-				return node;
-			});
-		VoiceOver._core.on('error', function (e) {
-			console.error('🔇 ', e);
-		});
-		VoiceOver._core.on('meter', function (e) {
-			OutputMeters.update(($o) => {
-				const absMax = Math.max(e.max, Math.abs(e.min));
-				$o = { ...$o, SpeechAudible: absMax };
-				return $o;
-			})
-		})
-		VoiceOver._core.on('load', () => {
-			VoiceOver.subscribeToStores()
-			SpeechCoreLoaded.set(true);
-			VoiceOver.status = 'ready';
-			console.log('Speech core loaded  🎤');
-			VoiceOver.patch();
-		});	
+		const metering: Functionality = customEvents.meter
+		VoiceOver.subscribeToStores()
+		super.init(
+			{ id: 'speech', renderer: VoiceOver._core },
+			super.actx,
+			{
+				connectTo: { sidechain: true },
+				extraFunctionality: [metering]
+			}
+		);
+
+
+		// VoiceOver._core.on('load', () => {
+		// 	VoiceOver.subscribeToStores()
+		// 	SpeechCoreLoaded.set(true);
+		// 	VoiceOver.status = 'ready';
+		// 	console.log('Speech core loaded  🎤');
+		// 	VoiceOver.patch();
+		// });	
 	}
 
-	/**
-	 * @name patch
-	 * @description 
-	 * connects the VoiceOver core to the hardware output
-	 * and also to the main WebRenderer instance handling the music.
-	 * Which of course has already loaded cleanly, right?
-	 */
-	private patch() {
-		super.connectToDestination(VoiceOver.voiceEndNode);
-		super.connectToMain(VoiceOver.voiceEndNode);
-	}
+	// /**
+	//  * @name patch
+	//  * @description
+	//  * connects the VoiceOver core to the hardware output
+	//  * and also to the main WebAudioRenderer instance handling the music.
+	//  * Which of course has already loaded cleanly, right?
+	//  */
+	// private patch() {
+	// 	super.connectToDestination(VoiceOver.voiceEndNode);
+	// 	super.connectToMusic(VoiceOver.voiceEndNode);
+	// }
 
 	/**
 	 * @name playSpeechFromVFS
@@ -127,9 +121,6 @@ export class VoiceCore extends AudioCore {
 	get sidechain() {
 		return this._sidechain;
 	}
-	get voiceEndNode() {
-		return get(this._endNodes).mainCore;
-	}
 	get voiceVolume() {
 		return this._voiceVolume;
 	}
@@ -142,18 +133,6 @@ export class VoiceCore extends AudioCore {
 	set status(status: AudioCoreStatus) {
 		this._voiceCoreStatus.update((s) => {
 			return status;
-		});
-	}
-	set voiceEndNode(node: AudioNode) {
-		this._endNodes.update((endNodes) => {
-			endNodes.mainCore = node;
-			return endNodes;
-		});
-	}
-	set silentVoiceEndNode(node: AudioNode) {
-		this._endNodes.update((endNodes) => {
-			endNodes.silentCore = node;
-			return endNodes;
 		});
 	}
 }

--- a/src/lib/classes/Speech.ts
+++ b/src/lib/classes/Speech.ts
@@ -6,7 +6,7 @@ import { MainAudioClass } from '$lib/classes/Audio';
 import { el } from '@elemaudio/core';
 import { PlaylistMusic } from '$lib/stores/stores';
 import { attenuateStereo, driftingSamplesPlayer } from '$lib/audio/AudioFunctions';
-import { customEvents } from '$lib/audio/EventHandlers';
+import { eventExpressions } from '$lib/audio/AudoEventExpressions';
 
 
 /** ════════╡ Speech WebAudioRenderer Core ╞═══════
@@ -36,37 +36,6 @@ export class VoiceCore extends MainAudioClass {
 			this._currentMetadata = $p.currentChapter as AssetMetadata;
 		});
 	}
-
-	/**
-	 * @name init
-	 * @description Initialise the main WebAudioRenderer instances handling the Speech 
-	 * asynchronously and store in VoiceCore class as this._endNodes
-	 */
-	override async init(): Promise<void> {
-		const metering: Functionality = customEvents.meter
-		super.init({
-			namedRenderer: {
-				id: 'speech',
-				renderer: VoiceOver._core
-			},
-			options: {
-				connectTo: { sidechain: true, destination: true },
-				extraFunctionality: [metering]
-			}
-		})
-	}
-
-	// /**
-	//  * @name patch
-	//  * @description
-	//  * connects the VoiceOver core to the hardware output
-	//  * and also to the main WebAudioRenderer instance handling the music.
-	//  * Which of course has already loaded cleanly, right?
-	//  */
-	// private patch() {
-	// 	super.connectToDestination(VoiceOver.voiceEndNode);
-	// 	super.connectToMusic(VoiceOver.voiceEndNode);
-	// }
 
 	/**
 	 * @name playSpeechFromVFS

--- a/src/lib/components/Cables.svelte
+++ b/src/lib/components/Cables.svelte
@@ -9,8 +9,6 @@
 	import Initialisation from './pure/Initialisation.svelte';
 	import { onMount } from 'svelte';
 	import { Utils } from '$lib/classes/Utils'
-	import { customEvents } from '$lib/audio/EventHandlers';
-	import { VoiceOver } from '$lib/classes/Speech';
 
 	export let patch: string;
 	export let bg: boolean = false;
@@ -22,7 +20,6 @@
 		CablesText.set( [ Utils.rotateString($CablesText[0]), Utils.rotateString($CablesText[1]) ] )
 		spinText($CablesText) 
 	}
-
 
 	const initializeCables =  () => {
 		CablesPatch.set ( new CABLES.Patch({
@@ -57,8 +54,6 @@
 		$CablesAudioContext = CABLES.WEBAUDIO.getAudioContext()
 		spinText();	
 	}
-
-
 
 	function spinText(  prompts:string[] = ["End","Proc"]  ) {
 	if ( $CablesIsLoaded ) {

--- a/src/lib/components/Cables.svelte
+++ b/src/lib/components/Cables.svelte
@@ -5,12 +5,11 @@
 			CablesText,
 			CablesIsLoaded,
 			CablesAudioContext,
-			MusicCoreLoaded,
-			SpeechCoreLoaded
 		} from '$lib/stores/stores';
-	import { AudioMain } from '$lib/classes/Audio';
+	import Initialisation from './pure/Initialisation.svelte';
 	import { onMount } from 'svelte';
-	import { Utils } from '$lib/classes/Utils';
+	import { Utils } from '$lib/classes/Utils'
+	import { customEvents } from '$lib/audio/EventHandlers';
 	import { VoiceOver } from '$lib/classes/Speech';
 
 	export let patch: string;
@@ -25,7 +24,7 @@
 	}
 
 
-	const initializeCables = async () => {
+	const initializeCables =  () => {
 		CablesPatch.set ( new CABLES.Patch({
 			patch: CABLES.exportedPatch,
 			prefixAssetPath: `/cables/${patch}/`,
@@ -53,11 +52,13 @@
 		console.log('Cables Patch initialized');
 	} 
 
-	function patchFinishedLoading() {
+	async function  patchFinishedLoading() {
 		$CablesIsLoaded = true;
-		$CablesAudioContext = CABLES.WEBAudioMain.getAudioContext()
+		$CablesAudioContext = CABLES.WEBAUDIO.getAudioContext()
 		spinText();	
 	}
+
+
 
 	function spinText(  prompts:string[] = ["End","Proc"]  ) {
 	if ( $CablesIsLoaded ) {
@@ -65,22 +66,10 @@
 		}
 	}
 
-	onMount(async () => {
-
-		const initialisers:Array<Promise<any>> = [
-			AudioMain.init( {id:'music', renderer: AudioMain._core },  $CablesAudioContext),
-			AudioMain.init( {id:'silent', renderer: AudioMain._silentCore },  $CablesAudioContext),	
-			VoiceOver.init()
-			]
-		await initializeCables().then (()=>{
-		Promise.all(initialisers).then( () => { 
-			console.log('Initialisation completed')
-			$MusicCoreLoaded = true;
-			$SpeechCoreLoaded = true;
-			})
+	onMount( () => {
+		initializeCables();
 		})
-	})
-	
+
 	</script>
 
 <svelte:head>
@@ -95,4 +84,5 @@
 		height="100%"
 		style="width: 100%; height: 100%; z-index: {bg? -137: 0}; position: fixed;"
 	/>
+	<Initialisation />
 </div>

--- a/src/lib/components/Cables.svelte
+++ b/src/lib/components/Cables.svelte
@@ -6,21 +6,17 @@
 			CablesIsLoaded,
 			CablesAudioContext,
 			MusicCoreLoaded,
-
 			SpeechCoreLoaded
-
 		} from '$lib/stores/stores';
 	import { AudioMain } from '$lib/classes/Audio';
 	import { onMount } from 'svelte';
 	import { Utils } from '$lib/classes/Utils';
-	import WebAudioRenderer from '@elemaudio/web-renderer';
 	import { VoiceOver } from '$lib/classes/Speech';
 
 	export let patch: string;
 	export let bg: boolean = false;
 	export let spin: boolean = false;
-
-		
+	
 	let pathPatch: string = `/cables/${patch}/patch.js`;	
 
 	$: if (spin) { 

--- a/src/lib/components/Cables.svelte
+++ b/src/lib/components/Cables.svelte
@@ -10,7 +10,7 @@
 			SpeechCoreLoaded
 
 		} from '$lib/stores/stores';
-	import { Audio } from '$lib/classes/Audio';
+	import { AudioMain } from '$lib/classes/Audio';
 	import { onMount } from 'svelte';
 	import { Utils } from '$lib/classes/Utils';
 	import WebAudioRenderer from '@elemaudio/web-renderer';
@@ -59,7 +59,7 @@
 
 	function patchFinishedLoading() {
 		$CablesIsLoaded = true;
-		$CablesAudioContext = CABLES.WEBAUDIO.getAudioContext()
+		$CablesAudioContext = CABLES.WEBAudioMain.getAudioContext()
 		spinText();	
 	}
 
@@ -72,8 +72,8 @@
 	onMount(async () => {
 
 		const initialisers:Array<Promise<any>> = [
-			Audio.init( {id:'music', renderer: Audio._core },  $CablesAudioContext),
-			Audio.init( {id:'silent', renderer: Audio._silentCore },  $CablesAudioContext),	
+			AudioMain.init( {id:'music', renderer: AudioMain._core },  $CablesAudioContext),
+			AudioMain.init( {id:'silent', renderer: AudioMain._silentCore },  $CablesAudioContext),	
 			VoiceOver.init()
 			]
 		await initializeCables().then (()=>{

--- a/src/lib/components/CanvasBody.svelte
+++ b/src/lib/components/CanvasBody.svelte
@@ -2,23 +2,14 @@
 
 	import Cables from '$lib/components/Cables.svelte';
 	import { CablesIsLoaded } from '$lib/stores/stores';
-	import { ProgressRadial } from '@skeletonlabs/skeleton';
 
 	export let spin: boolean;
 
 </script>
 
-<!-- Loading spinner -->
+
 {#if !$CablesIsLoaded  } 
-		<div class="absolute inset-0 flex justify-center items-center">
-			<ProgressRadial 
-			value={ undefined }
-			font= {8}
-			width='w-4' 
-			stroke={5} 
-			meter="stroke-secondary-500" 
-			track="stroke-secondary-300/30" />
-		</div>
+	<!-- Loading spinner? -->	
 {/if}
 
 <Cables patch="ENDPROC010" bg={true} bind:spin />

--- a/src/lib/components/ElementaryPlayer.svelte
+++ b/src/lib/components/ElementaryPlayer.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-	import { Audio } from '$lib/classes/Audio';
+	import { AudioMain } from '$lib/classes/Audio';
 	import { Icon } from '@steeze-ui/svelte-icon';
 	import { PauseOutline, PlayOutline, QueryQueue } from '@steeze-ui/carbon-icons';
 	import { Decoded, PlaylistMusic } from '$lib/stores/stores';
 	import PlaylistView from './PlaylistView.svelte';
 	import { onDestroy } from 'svelte';
 
-	const { audioStatus } = Audio.stores;
+	const { audioStatus } = AudioMain.stores;
 
 	let trackTitles: Array<string>;
 
@@ -14,7 +14,7 @@
 	$: isPlaying = $audioStatus === 'playing';
 	
 	onDestroy(() => {
-	//	Audio.actx.close();
+	//	AudioMain.actx.close();
 	});
 
 </script>

--- a/src/lib/components/EndProcAppBar.svelte
+++ b/src/lib/components/EndProcAppBar.svelte
@@ -2,7 +2,7 @@
 	import { fade } from 'svelte/transition';
 	import { AppBar } from '@skeletonlabs/skeleton';
 	import { Icon } from '@steeze-ui/svelte-icon';
-	import { ChartRadial, Cube } from '@steeze-ui/carbon-icons';
+	import { ChartRadial } from '@steeze-ui/carbon-icons';
 	import ElementaryPlayer from '$lib/components/ElementaryPlayer.svelte';
 	import Progress from '$lib/components/Progress.svelte';
 	import { CablesIsLoaded, PlaysCount, PlaylistMusic, VFS_PATH_PREFIX, Decoded } from '$lib/stores/stores';

--- a/src/lib/components/EndProcAppBar.svelte
+++ b/src/lib/components/EndProcAppBar.svelte
@@ -6,7 +6,7 @@
 	import ElementaryPlayer from '$lib/components/ElementaryPlayer.svelte';
 	import Progress from '$lib/components/Progress.svelte';
 	import { CablesIsLoaded, PlaysCount, PlaylistMusic, VFS_PATH_PREFIX, Decoded } from '$lib/stores/stores';
-	import { Audio } from '$lib/classes/Audio';
+	import { AudioMain } from '$lib/classes/Audio';
 	import { createEventDispatcher } from 'svelte';
 	import { get } from 'svelte/store';
 	import { handlePlaylistChoice } from '$lib/functions/handlePlaylistChoice';
@@ -15,7 +15,7 @@
 
 	const dispatch = createEventDispatcher();
 
-	const { audioStatus } = Audio.stores;
+	const { audioStatus } = AudioMain.stores;
 
 	$: audioBuffersReady = $Decoded.done;
 	$: isPlaying = $audioStatus === 'playing';
@@ -43,7 +43,7 @@
 	 * what happens when the user presses the Play/Pause button
 	 */
 	function playPauseLogic() {
-		if (!Audio.buffersReady) {
+		if (!AudioMain.buffersReady) {
 			return;
 		}
 		// initialise first track data if this is the first play
@@ -62,10 +62,10 @@
 								console.log('Cued track:', $PlaylistMusic.currentTrack?.title)
 
 		if ($audioStatus === 'playing') {
-			Audio.pause();
+			AudioMain.pause();
 			return;
 		} else {
-			Audio.unmute();
+			AudioMain.unmute();
 		}
 	}
 

--- a/src/lib/components/NowPlaying.svelte
+++ b/src/lib/components/NowPlaying.svelte
@@ -1,6 +1,6 @@
 <script lang='ts'>
 	import {PlaylistMusic} from '$lib/stores/stores';
-	import {Audio} from '$lib/classes/Audio';
+	import {AudioMain} from '$lib/classes/Audio';
 	import DescriptionList from './DescriptionList.svelte';
 	import { fade } from 'svelte/transition';
 	const { audioStatus } = AudioMain.stores

--- a/src/lib/components/NowPlaying.svelte
+++ b/src/lib/components/NowPlaying.svelte
@@ -3,7 +3,7 @@
 	import {Audio} from '$lib/classes/Audio';
 	import DescriptionList from './DescriptionList.svelte';
 	import { fade } from 'svelte/transition';
-	const { audioStatus } = Audio.stores
+	const { audioStatus } = AudioMain.stores
 
 	export let show:boolean = false;
 

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -5,7 +5,7 @@
 import { ListBox, ListBoxItem } from '@skeletonlabs/skeleton';
 import { Icon } from '@steeze-ui/svelte-icon';
 import  {CircleDash, CircleFilled} from '@steeze-ui/carbon-icons';
-import {Audio} from '$lib/classes/Audio';
+import {AudioMain} from '$lib/classes/Audio';
 import { Utils, formatTitleFromGlobalPath } from '$lib/classes/Utils';
 import { handlePlaylistChoice } from '$lib/functions/handlePlaylistChoice';
 

--- a/src/lib/components/PlaylistView.svelte
+++ b/src/lib/components/PlaylistView.svelte
@@ -15,7 +15,7 @@ let valueSingle: number;
 
 const dividerClass = 'my-12 h-0.5 border-t-0 bg-primary-800 opacity-100 dark:opacity-50'
 
-$: current = Audio.currentTrackTitle;
+$: current = AudioMain.currentTrackTitle;
 
 
 </script>

--- a/src/lib/components/Progress.svelte
+++ b/src/lib/components/Progress.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { PlaylistMusic } from '$lib/stores/stores';
-	import { Audio } from '$lib/classes/Audio';
+	import { AudioMain } from '$lib/classes/Audio';
 	import { ProgressBar } from '@skeletonlabs/skeleton';
 	import { Scrubbing } from '$lib/stores/stores';
 	import { createEventDispatcher } from 'svelte';
@@ -22,25 +22,25 @@
 			durationMs: durationSecs * 1000
 		}}
 	$: if (progress >= 0.99 && !$Scrubbing) {
-		Audio.playWithScrub( {...samplerParams('stop')} );
+		AudioMain.playWithScrub( {...samplerParams('stop')} );
 		dispatch('cueNext', $PlaylistMusic.currentTrack?.title);
 	}
 
 	function handleScrub(e: any) {
 		if (!$Scrubbing) return;
-		Audio.status = 'playing';
+		AudioMain.status = 'playing';
 		const { clientX, target } = e;
 		const { left, width } = target.getBoundingClientRect();
 		const x = clientX - left;
 		const percent = x / width;
 		startOffset = percent
-		Audio.playWithScrub( {...samplerParams('stop'), startOffset} );
+		AudioMain.playWithScrub( {...samplerParams('stop'), startOffset} );
 	}
 
 	function replay() {
 		if (!$Scrubbing) return;
 		$Scrubbing = false;
-		Audio.playWithScrub( {...samplerParams('start'), startOffset})
+		AudioMain.playWithScrub( {...samplerParams('start'), startOffset})
 		}
 
 

--- a/src/lib/components/Speech/TextToSpeech.svelte
+++ b/src/lib/components/Speech/TextToSpeech.svelte
@@ -41,7 +41,7 @@
     }
 
     onMount(() => {     
-         VoiceOver.init();
+       //  VoiceOver.init();
         })
 
 

--- a/src/lib/components/images/SplashSVG.svelte
+++ b/src/lib/components/images/SplashSVG.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-import { Audio } from '$lib/classes/Audio';
+import { AudioMain } from '$lib/classes/Audio';
 
-const { audioStatus } = Audio.stores
+const { audioStatus } = AudioMain.stores
 
 $: isPlaying = $audioStatus === 'playing';
 

--- a/src/lib/components/pure/Initialisation.svelte
+++ b/src/lib/components/pure/Initialisation.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+import { customEvents } from "$lib/audio/EventHandlers";
+import { AudioMain } from "$lib/classes/Audio";
+import { VoiceOver } from "$lib/classes/Speech";
+import { CablesAudioContext, MusicCoreLoaded, SpeechCoreLoaded } from "$lib/stores/stores";
+
+ async function initialiseAudioRenderers() {
+
+		if ( Object.hasOwn( $CablesAudioContext,'__elemRegistered') ) {
+			console.log('Elementary already registered')
+			return Promise.resolve(false)
+		}
+
+			await AudioMain.init({
+				namedRenderer: { id:'music', renderer: AudioMain._core }, 
+				ctx: $CablesAudioContext,
+				options: {
+					connectTo: {
+						destination: true,
+						visualiser: true,
+					},
+				}
+			});
+			await AudioMain.init({
+				namedRenderer: { id:'silent', renderer: AudioMain._silentCore }, 
+				ctx: $CablesAudioContext,
+				options: {
+					connectTo: {
+						nothing: true,
+					},
+					extraFunctionality: [
+						customEvents.progressSignal
+					],
+				}
+			});
+			await VoiceOver.init()
+
+			return Promise.resolve(true)
+        }
+
+function done( element: HTMLElement, answer: boolean){
+			console.log('Audio Renderers initialised?', answer)
+			$MusicCoreLoaded = true;
+			$SpeechCoreLoaded = true;
+		}
+
+</script>
+
+{#if $CablesAudioContext}
+	{#await initialiseAudioRenderers()}
+	<span class='info'> intialising audio renderers </span>
+	{:then answer }
+	<div data-comment use:done={answer} />
+	{/await}
+{/if}

--- a/src/lib/components/pure/Initialisation.svelte
+++ b/src/lib/components/pure/Initialisation.svelte
@@ -1,18 +1,15 @@
 <script lang="ts">
-import { customEvents } from "$lib/audio/EventHandlers";
+import { eventExpressions } from "$lib/audio/AudoEventExpressions";
 import { AudioMain } from "$lib/classes/Audio";
 import { VoiceOver } from "$lib/classes/Speech";
 import { CablesAudioContext, MusicCoreLoaded, SpeechCoreLoaded } from "$lib/stores/stores";
 
  async function initialiseAudioRenderers() {
-
-		if ( Object.hasOwn( $CablesAudioContext,'__elemRegistered') ) {
-			console.log('Elementary already registered')
-			return Promise.resolve(false)
-		}
-
 			await AudioMain.init({
-				namedRenderer: { id:'music', renderer: AudioMain._core }, 
+				namedRenderer: { 
+					id:'music', 
+					renderer: AudioMain._core 
+				}, 
 				ctx: $CablesAudioContext,
 				options: {
 					connectTo: {
@@ -22,20 +19,33 @@ import { CablesAudioContext, MusicCoreLoaded, SpeechCoreLoaded } from "$lib/stor
 				}
 			});
 			await AudioMain.init({
-				namedRenderer: { id:'silent', renderer: AudioMain._silentCore }, 
+				namedRenderer: { 
+					id:'silent', 
+					renderer: AudioMain._silentCore 
+				}, 
 				ctx: $CablesAudioContext,
 				options: {
 					connectTo: {
-						nothing: true,
+						nothing: true
 					},
-					extraFunctionality: [
-						customEvents.progressSignal
-					],
+					eventExpressions: { snapshot: eventExpressions.progress } ,
 				}
 			});
-			await VoiceOver.init()
+			await VoiceOver.init({
+				namedRenderer: {
+				id: 'speech',
+				renderer: VoiceOver._core
+			},
+			options: {
+				connectTo: { 
+					sidechain: true, 
+					destination: true 
+				},
+				eventExpressions: { meter: eventExpressions.meter }
+			}
+		});
 
-			return Promise.resolve(true)
+		return Promise.resolve(true)
         }
 
 function done( element: HTMLElement, answer: boolean){
@@ -48,7 +58,7 @@ function done( element: HTMLElement, answer: boolean){
 
 {#if $CablesAudioContext}
 	{#await initialiseAudioRenderers()}
-	<span class='info'> intialising audio renderers </span>
+	<div data-comment> Intialising audio renderers. </div>
 	{:then answer }
 	<div data-comment use:done={answer} />
 	{/await}

--- a/src/lib/components/remote/AssetLoader.svelte
+++ b/src/lib/components/remote/AssetLoader.svelte
@@ -21,7 +21,7 @@
 	import type { AssetCategories, StructuredAssetContainer } from '../../../typeDeclarations';
 	import { ContextSampleRate, Decoded, VFS_Entries } from '$lib/stores/stores';
 	import { Utils, stripTags } from '$lib/classes/Utils';
-	import { Audio } from '$lib/classes/Audio';
+	import { AudioMain } from '$lib/classes/Audio';
 	import { assign, coreForCategory, sumLengthsOfAllArraysInVFSStore as VFS_Entries_Checksum } from '$lib/classes/Assets';
 
  	export let metadata: PageData;
@@ -57,7 +57,7 @@
 					const storedVFSDictionaryForCategory:Array<StructuredAssetContainer> = $VFS_Entries[key as AssetCategories];
 					try {
 						storedVFSDictionaryForCategory.forEach((entry) => {
-						Audio.updateVFStoCore(entry, coreForCategory(key as AssetCategories));
+						AudioMain.updateVFStoCore(entry, coreForCategory(key as AssetCategories));
 						});
 					} catch (error) {
 						console.warn( 'Hit all done flag.' )

--- a/src/lib/functions/handlePlaylistChoice.ts
+++ b/src/lib/functions/handlePlaylistChoice.ts
@@ -1,7 +1,7 @@
 
 import { get } from 'svelte/store';
 import { VFS_PATH_PREFIX, PlaylistMusic } from '$lib/stores/stores';
-import { Audio } from '$lib/classes/Audio';
+import { AudioMain } from '$lib/classes/Audio';
 import type { PlaylistContainer } from '../../typeDeclarations';
 
 let $playlistMusic: PlaylistContainer;
@@ -27,7 +27,7 @@ export function handlePlaylistChoice(e?: any, name?: string) {
         return $pl;
     });
 
-    Audio.status = 'playing';
-    Audio.playWithScrub({ trigger: 0, startOffset: 0 });
-    Audio.playWithScrub({ trigger: 1, startOffset: 0 });
+    AudioMain.status = 'playing';
+    AudioMain.playWithScrub({ trigger: 0, startOffset: 0 });
+    AudioMain.playWithScrub({ trigger: 1, startOffset: 0 });
 }

--- a/src/lib/stores/stores.ts
+++ b/src/lib/stores/stores.ts
@@ -47,14 +47,11 @@ export const OutputMeters: Writable<MetersContainer> = writable(
  * @Concept dynamic namespaces system for VFS?
  */
 export const VFS_PATH_PREFIX: Readable<string> = readable('vfs::');
-
 export const VFS_Entries: Writable<AssetCategoryContainers & { done: boolean }> = writable({
 	music: [],
 	speech: [],
 	done: false,
 });
-
-
 
 
 //----------------- Sounding Assets -----------------------
@@ -92,7 +89,6 @@ export const Scrubbing: Writable<boolean> = writable(false);
 
 
 //----------------- WebAudio -----------------------
-
 export const EndNodes: Writable<Map<RendererIdentifiers, AudioNode>> = writable(new Map<RendererIdentifiers, AudioNode>());
 
 

--- a/src/lib/stores/stores.ts
+++ b/src/lib/stores/stores.ts
@@ -1,7 +1,7 @@
 // This file defines the stores used in the app
 
 import { writable, type Readable, type Writable, readable } from 'svelte/store';
-import type { SinglePost, RawFFT, PlaylistContainer, MetersContainer, AssetCategoryContainers } from '../../typeDeclarations';
+import type { SinglePost, RawFFT, PlaylistContainer, MetersContainer, AssetCategoryContainers, RendererIdentifiers } from '../../typeDeclarations';
 
 //---- UX / State related -------------------
 export const Decoded: Writable<{ done: boolean; bounds?: number }> = writable({
@@ -91,9 +91,9 @@ export const Scrubbing: Writable<boolean> = writable(false);
 
 
 
+//----------------- WebAudio -----------------------
 
-
-
+export const EndNodes: Writable<Map<RendererIdentifiers, AudioNode>> = writable(new Map<RendererIdentifiers, AudioNode>());
 
 
 //---------- deprecating zone --- 🚮 --------------------
@@ -101,7 +101,7 @@ export const Scrubbing: Writable<boolean> = writable(false);
  * @deprecated 
  * 
  * */
-export const EndNodes: Writable<any> = writable({ elem: null, cables: null });
+
 export const rawFFT: Writable<RawFFT> = writable({
 	real: new Float32Array(0),
 	imag: new Float32Array(0)

--- a/src/typeDeclarations.d.ts
+++ b/src/typeDeclarations.d.ts
@@ -103,6 +103,15 @@ type ResolvedPageData = CategoryMapping<AssetCategories> & {
 }
 
 //════════╡ AudioEngine ╞═══════
+
+interface MessageEvent { data: number }
+interface MeterEvent extends MessageEvent { min: number, max: number }
+interface AudioEvent extends MessageEvent, MeterEvent { };
+type AudioEventExpression<T> = {
+	progress: any;
+	meter: any;
+};
+
 interface RendererInitialisationProps {
 	namedRenderer: NamedWebAudioRenderer,
 	ctx?: AudioContext,
@@ -115,12 +124,11 @@ interface stereoOut {
 type Signal = NodeRepr_t;
 type StereoSignal = { left: NodeRepr_t; right: NodeRepr_t };
 type Functionality = Function
-type CustomEventHandler = { [key: string]: (e: any) => void }
 type RendererIdentifiers = 'silent' | 'music' | 'speech'
 type NamedWebAudioRenderer = { id: RendererIdentifiers, renderer: WebAudioRenderer }
 type InitialisationOptions = {
 	connectTo?: { destination?: boolean, visualiser?: boolean, sidechain?: boolean, nothing?: boolean },
-	extraFunctionality?: Array<Functionality>
+	eventExpressions?: {},
 }
 type RawFFT = { real: Float32Array; imag: Float32Array };
 type MainAudioStatus =

--- a/src/typeDeclarations.d.ts
+++ b/src/typeDeclarations.d.ts
@@ -54,11 +54,8 @@ type MetersContainer = {
 
 type TitlesPaths = { titles: string[], paths: string[] }
 type Url = string;
-
-// https://chat.openai.com/c/9e74f559-27b4-4baf-b4b8-f4ab637ecc86
 type AssetCategories = 'music' | 'speech';
-type AssetCategoryContainers = { [K in AssetCategories]: any } & { other?: any };
-
+type AssetCategoryContainers = { [K in AssetCategories]: any } & { other?: any }; // https://chat.openai.com/c/9e74f559-27b4-4baf-b4b8-f4ab637ecc86
 type AudioAssetMetadata = {
 	category: AssetCategories
 	mediaItemUrl: string;
@@ -106,7 +103,11 @@ type ResolvedPageData = CategoryMapping<AssetCategories> & {
 }
 
 //════════╡ AudioEngine ╞═══════
-
+interface RendererInitialisationProps {
+	namedRenderer: NamedWebAudioRenderer,
+	ctx?: AudioContext,
+	options?: InitialisationOptions
+}
 interface stereoOut {
 	props: {};
 	stereoSignal: StereoSignal;
@@ -117,8 +118,8 @@ type Functionality = Function
 type CustomEventHandler = { [key: string]: (e: any) => void }
 type RendererIdentifiers = 'silent' | 'music' | 'speech'
 type NamedWebAudioRenderer = { id: RendererIdentifiers, renderer: WebAudioRenderer }
-type WebAudioRendererInitOptions = {
-	connectTo: { destination?: boolean, visualiser?: boolean, sidechain?: boolean, silence?: boolean },
+type InitialisationOptions = {
+	connectTo?: { destination?: boolean, visualiser?: boolean, sidechain?: boolean, nothing?: boolean },
 	extraFunctionality?: Array<Functionality>
 }
 type RawFFT = { real: Float32Array; imag: Float32Array };

--- a/src/typeDeclarations.d.ts
+++ b/src/typeDeclarations.d.ts
@@ -21,9 +21,7 @@ interface PlaylistContainer {
 	show?: boolean;
 	durations: Map<string, number>;
 }
-type RawFFT = { real: Float32Array; imag: Float32Array };
-type Signal = NodeRepr_t;
-type StereoSignal = { left: NodeRepr_t; right: NodeRepr_t };
+
 type SamplerOptions = {
 	vfsPath?: string; // defaults to current track
 	trigger?: Signal | number;
@@ -50,17 +48,6 @@ type MetersContainer = {
 	SpeechAudible?: number,
 	SpeechSilent?: number,
 }
-type AudioCoreStatus =
-	| 'suspended'
-	| 'loading'
-	| 'resuming'
-	| 'playing'
-	| 'paused'
-	| 'closed '
-	| 'running'
-	| 'ready'
-	| 'scrubbing'
-	| 'error';
 
 
 //════════╡ Data  ╞═══════
@@ -118,10 +105,31 @@ type ResolvedPageData = CategoryMapping<AssetCategories> & {
 	};
 }
 
-//════════╡ AudioEngine :: Interfaces ╞═══════
+//════════╡ AudioEngine ╞═══════
 
 interface stereoOut {
 	props: {};
 	stereoSignal: StereoSignal;
 }
-
+type Signal = NodeRepr_t;
+type StereoSignal = { left: NodeRepr_t; right: NodeRepr_t };
+type Functionality = Function
+type CustomEventHandler = { [key: string]: (e: any) => void }
+type RendererIdentifiers = 'silent' | 'music' | 'speech'
+type NamedWebAudioRenderer = { id: RendererIdentifiers, renderer: WebAudioRenderer }
+type WebAudioRendererInitOptions = {
+	connectTo: { destination?: boolean, visualiser?: boolean, sidechain?: boolean, silence?: boolean },
+	extraFunctionality?: Array<Functionality>
+}
+type RawFFT = { real: Float32Array; imag: Float32Array };
+type AudioCoreStatus =
+	| 'suspended'
+	| 'loading'
+	| 'resuming'
+	| 'playing'
+	| 'paused'
+	| 'closed '
+	| 'running'
+	| 'ready'
+	| 'scrubbing'
+	| 'error';

--- a/src/typeDeclarations.d.ts
+++ b/src/typeDeclarations.d.ts
@@ -122,7 +122,7 @@ type WebAudioRendererInitOptions = {
 	extraFunctionality?: Array<Functionality>
 }
 type RawFFT = { real: Float32Array; imag: Float32Array };
-type AudioCoreStatus =
+type MainAudioStatus =
 	| 'suspended'
 	| 'loading'
 	| 'resuming'


### PR DESCRIPTION
Major refactoring of multiple WebRenderer instancing. 
Came up with a shared init() functional layer for instancing and attaching Event driven expressions ( aka callbacks triggered by WASM core hooks, el.snapshot etc. 

Instancing of multiple WRs is clearer to design and debug, as each one needs to have it's own VFS and routing options. Going to work with this system for a while, and see if it begins to be a better experience. 

